### PR TITLE
feature: yaml file for crawler scheduler and rabbitmq cluster

### DIFF
--- a/deploy/crawler-scheduler/cronjob.yaml
+++ b/deploy/crawler-scheduler/cronjob.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: crawler-scheduler
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: crawler-scheduler
+            image: alan0415/crawler-scheduler
+            env:
+            - name: TSMC_RABBITMQ_HOST
+              value: "10.40.4.94"
+            - name: TSMC_RABBITMQ_PORT
+              value: "5672"
+            - name: TSMC_RABBITMQ_USER
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-account
+                  key: USER_NAME
+                  optional: false
+            - name: TSMC_RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-account
+                  key: PASSWORD
+                  optional: false

--- a/deploy/crawler-scheduler/sercet.yaml
+++ b/deploy/crawler-scheduler/sercet.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-account
+type: Opaque
+stringData:
+  USER_NAME: "default_user_X_fMKPOAtssY3xzkukX"
+  PASSWORD: "O1OS5-U9k8GybBEvKVCR7Sa5MBZ39p2o"

--- a/deploy/rabbitmq/deploy.yaml
+++ b/deploy/rabbitmq/deploy.yaml
@@ -1,0 +1,13 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: resource-limits
+spec:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 300m
+      memory: 1Gi
+    limits:
+      cpu: 400m
+      memory: 1Gi


### PR DESCRIPTION
Add yaml file for deploy RabbitMQ and crawler scheduler cronjob.
RabbitMq cluster deployment reference from [here](https://www.rabbitmq.com/kubernetes/operator/quickstart-operator.html)