### PR TITLE
feature: helm chart for crawler-scheduler cronjob

### DIFF
--- a/tsmc-digital-business/.helmignore
+++ b/tsmc-digital-business/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tsmc-digital-business/Chart.yaml
+++ b/tsmc-digital-business/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: tsmc-digital-business
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/tsmc-digital-business/templates/NOTES.txt
+++ b/tsmc-digital-business/templates/NOTES.txt
@@ -1,0 +1,14 @@
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+Deploy detail:
+1. The following Cronjobs are scheduled:
+{{- range $job := .Values.jobs }}
+  - name: {{ $job.name }}
+    image: "{{ $job.image.repository }}:{{ $job.image.tag }}"
+    schedule: {{ $job.schedule | quote }}
+{{- end }}

--- a/tsmc-digital-business/templates/_helpers.tpl
+++ b/tsmc-digital-business/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tsmc-digital-business.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tsmc-digital-business.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tsmc-digital-business.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tsmc-digital-business.labels" -}}
+helm.sh/chart: {{ include "tsmc-digital-business.chart" . }}
+{{ include "tsmc-digital-business.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tsmc-digital-business.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tsmc-digital-business.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tsmc-digital-business.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tsmc-digital-business.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tsmc-digital-business/templates/cronjob.yaml
+++ b/tsmc-digital-business/templates/cronjob.yaml
@@ -1,0 +1,26 @@
+{{- $chart_name := .Chart.Name }}
+{{- $chart_version := .Chart.Version | replace "+" "_" }}
+{{- $release_name := .Release.Name }}
+
+{{- range $job := .Values.jobs }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "{{ $release_name }}-{{ $job.name }}"
+spec:
+  schedule: {{ $job.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: {{ $job.restartPolicy }}
+          containers:
+          - name: {{ $job.name }}
+            image: "{{ $job.image.repository }}:{{ $job.image.tag }}"
+            imagePullPolicy: {{ $job.image.imagePullPolicy }}
+            {{- with $job.env }}
+            env:
+{{ toYaml . | indent 12 }}
+            {{- end }}
+{{- end }}

--- a/tsmc-digital-business/values.yaml
+++ b/tsmc-digital-business/values.yaml
@@ -1,0 +1,25 @@
+jobs:
+  - name: crawler-scheduler
+    image:
+      repository: alan0415/crawler-scheduler
+      tag: latest
+      imagePullPolicy: Always
+    schedule: "* * * * *"
+    restartPolicy: Never
+    env:
+    - name: TSMC_RABBITMQ_HOST
+      value: "10.43.245.128"
+    - name: TSMC_RABBITMQ_PORT
+      value: "5672"
+    - name: TSMC_RABBITMQ_USER
+      valueFrom:
+        secretKeyRef:
+          name: rabbitmq-account
+          key: USER_NAME
+          optional: false
+    - name: TSMC_RABBITMQ_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: rabbitmq-account
+          key: PASSWORD
+          optional: false


### PR DESCRIPTION
Create a helm chart for install crawler-scheduler cronjob.
The default values used in helm will consumed the secret declare under /deploy/crawler-scheduler. If used another secret to store RabbitMQ account username/password, modify the values before install the helm chart.